### PR TITLE
Fix comment json format

### DIFF
--- a/conduit/articles/serializers.py
+++ b/conduit/articles/serializers.py
@@ -73,6 +73,7 @@ class CommentsSchema(CommentSchema):
 
     @post_dump
     def dump_comment(self, data):
+        data['author'] = data['author']['profile']
         return data
 
     @post_dump(pass_many=True)

--- a/conduit/articles/serializers.py
+++ b/conduit/articles/serializers.py
@@ -63,6 +63,7 @@ class CommentSchema(Schema):
 
     @post_dump
     def dump_comment(self, data):
+        data['author'] = data['author']['profile']
         return {'comment': data}
 
     class Meta:


### PR DESCRIPTION
With elm front-end, if there is a comment, there is an error while loading an article.

According to realworld api 
[https://github.com/gothinkster/realworld/tree/master/api#single-comment](url),

this is the right example.
```
{'comments': [{'updatedAt': '2016-02-18T03:22:56.637Z', 'body': 'It takes a Jacobian', 'createdAt': '2016-02-18T03:22:56.637Z', 'id': 1, 'author': {'image': 'https://i.stack.imgur.com/xHWG8.jpg', 'bio': 'I work at statefarm', 'following': False, 'username': 'jake'}}]}
```
but in flask-realworld,
we got this.

```
{'comments': [{'createdAt': '2017-08-30T05:22:41.529511+00:00', 'updatedAt': '2017-08-30T05:22:41.529540+00:00', 'body': '123', 'id': 1, 'author': {'profile': {'image': None, 'bio': None, 'email': 'u2@gmail.com', 'username': 'u2', 'following': False}}}]}
```

**The only difference between these is 'author' section.
We need to remove profile key and put profile's item to 'author' section.**

because I don't know how schema? works here, I just removed profile key like below...
```
data['author'] = data['author']['profile']
```
I think this is just a fast easy solution for this since I don't know how schema class works.
```
author = fields.Nested(ProfileSchema)
```
I knew this part has a problem. I don't know how to fix it lol.

