### PR TITLE
Updating psycopg2 to support Postgres 10

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -12,7 +12,7 @@ flask_apispec==0.3.2
 Flask==0.12.1
 PyJWT==1.5.0
 unicode_slugify==0.1.3
-psycopg2==2.6.2
+psycopg2==2.7.3.1
 Flask-Migrate==2.0.3
 gunicorn>=19.1.1
 Flask-Cors==3.0.2


### PR DESCRIPTION
This version does not work with Postgres 10.
As per https://github.com/psycopg/psycopg2/issues/594