### PR TITLE
Update article should execute datetime function

### DIFF
--- a/conduit/articles/views.py
+++ b/conduit/articles/views.py
@@ -62,7 +62,7 @@ def update_article(slug, **kwargs):
     article = Article.query.filter_by(slug=slug, author_id=current_user.profile.id).first()
     if not article:
         raise InvalidUsage.article_not_found()
-    article.update(updatedAt=dt.datetime.utcnow, **kwargs)
+    article.update(updatedAt=dt.datetime.utcnow(), **kwargs)
     article.save()
     return article
 


### PR DESCRIPTION
If you don't do this change you get an error:

```
SQLAlchemy only accepts Python DateTime objects
```

This fixes that problem and makes it work as intended.