### PR TITLE
[Bug Fix] [Add compatible code] deal API changes for marshmallow from…

### DIFF
--- a/conduit/profile/serializers.py
+++ b/conduit/profile/serializers.py
@@ -12,11 +12,11 @@ class ProfileSchema(Schema):
     profile = fields.Nested('self', exclude=('profile',), default=True, load_only=True)
 
     @pre_load
-    def make_user(self, data):
+    def make_user(self, data, **kwargs):
         return data['profile']
 
     @post_dump
-    def dump_user(self, data):
+    def dump_user(self, data, **kwargs):
         return {'profile': data}
 
     class Meta:


### PR DESCRIPTION
This could solve the issue : https://github.com/gothinkster/flask-realworld-example-app/issues/25

Based on [marshmallow change log](https://marshmallow.readthedocs.io/en/stable/changelog.html#rc7-2019-06-15)

> Backwards-incompatible: many is passed as a keyword argument to methods decorated with pre_load, post_load, pre_dump, post_dump, and validates_schema. partial is passed as a keyword argument to methods decorated with pre_load, post_load and validates_schema. **kwargs should be added to all decorated methods.

So there will be no error like : **TypeError: dump_user() got an unexpected keyword argument 'many'**