### PR TITLE
Fix unique constraint on userprofile.user_id

### DIFF
--- a/conduit/profile/models.py
+++ b/conduit/profile/models.py
@@ -15,7 +15,7 @@ class UserProfile(Model, SurrogatePK):
     # id is needed for primary join, it does work with SurrogatePK class
     id = db.Column(db.Integer, primary_key=True)
 
-    user_id = reference_col('users', nullable=False)
+    user_id = reference_col('users', nullable=False, unique=True)
     user = relationship('User', backref=db.backref('profile', uselist=False))
     follows = relationship('UserProfile',
                            secondary=followers_assoc,


### PR DESCRIPTION
I performed the database migration with postgres 9.6.6, and faced to the error : 

```
sqlalchemy.exc.ProgrammingError: (psycopg2.errors.InvalidForeignKey) there is no unique constraint matching given keys for referenced table "userprofile"
 [SQL: '\nCREATE TABLE followers_assoc (\n\tfollower INTEGER, \n\tfollowed_by INTEGER, \n\tFOREIGN KEY(followed_by) REFERENCES userprofile (user_id), \n\tFOREIGN KEY(follower) REFERENCES userprofile (user_id)\n)\n\n']
```

After added the unique constraint to userprofile.user_id, the migration can be performed successfully.