### PR TITLE
Remove lone type hint

### DIFF
--- a/conduit/user/models.py
+++ b/conduit/user/models.py
@@ -16,7 +16,7 @@ class User(SurrogatePK, Model):
     updated_at = Column(db.DateTime, nullable=False, default=dt.datetime.utcnow)
     bio = Column(db.String(300), nullable=True)
     image = Column(db.String(120), nullable=True)
-    token: str = ''
+    token = ''
 
     def __init__(self, username, email, password=None, **kwargs):
         """Create instance."""


### PR DESCRIPTION
There's just one type hint in this repo and it breaks Python 2 compatibility. I know, Python 2 is EOL, But it's the only thing breaking Python 2 compatibility... 😄 