### PR TITLE
Refactor deprecated yield_fixture decorator

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ from conduit.profile.models import UserProfile
 from .factories import UserFactory
 
 
-@pytest.yield_fixture(scope='function')
+@pytest.fixture(scope='function')
 def app():
     """An application for the tests."""
     _app = create_app(TestConfig)
@@ -35,7 +35,7 @@ def testapp(app):
     return TestApp(app)
 
 
-@pytest.yield_fixture(scope='function')
+@pytest.fixture(scope='function')
 def db(app):
     """A database for the tests."""
     _db.app = app


### PR DESCRIPTION
From the [pytest docs](https://docs.pytest.org/en/stable/yieldfixture.html):

> Since pytest-3.0, fixtures using the normal fixture decorator can use a yield statement to provide fixture values and execute teardown code, exactly like yield_fixture in previous versions.
> 
> Marking functions as yield_fixture is still supported, but deprecated and should not be used in new code.

As this repository is being used as a learning resource, it would be nice if we could remove these.