### PR TITLE
Fixes PyJWT and Flask-JWT-Extended version incompatiblity

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -9,8 +9,8 @@ marshmallow
 Flask_Bcrypt
 flask_apispec
 Flask
-PyJWT
-Flask-JWT-Extended
+PyJWT==1.6.1
+Flask-JWT-Extended==3.13.1
 unicode_slugify
 psycopg2
 Flask-Migrate


### PR DESCRIPTION
Running the current version of the projects results in the following error:
`ImportError: cannot import name 'jwt_optional' from 'flask_jwt_extended' (/opt/homebrew/lib/python3.9/site-packages/flask_jwt_extended/__init__.py)`

This is because of an issue between Flask-JWT-Extended and PyJWT versions documented at :[https://github.com/vimalloc/flask-jwt-extended/issues/204](https://github.com/vimalloc/flask-jwt-extended/issues/204)

The pull request sets Flask-JWT-Extended and PyJWT to versions 3.13.1 and 1.6.1 respectively, fixing the issue.