### PR TITLE
fix typo in article's schema plural naming.

### DIFF
--- a/conduit/articles/serializers.py
+++ b/conduit/articles/serializers.py
@@ -35,7 +35,7 @@ class ArticleSchema(Schema):
         strict = True
 
 
-class ArticleSchemas(ArticleSchema):
+class ArticlesSchema(ArticleSchema):
 
     @post_dump
     def dump_article(self, data, **kwargs):
@@ -83,6 +83,6 @@ class CommentsSchema(CommentSchema):
 
 
 article_schema = ArticleSchema()
-articles_schema = ArticleSchemas(many=True)
+articles_schema = ArticlesSchema(many=True)
 comment_schema = CommentSchema()
 comments_schema = CommentsSchema(many=True)


### PR DESCRIPTION
fix typo in article's schema plural naming.